### PR TITLE
add enable mulh flag

### DIFF
--- a/include/dromajo_template.h
+++ b/include/dromajo_template.h
@@ -1008,9 +1008,21 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
                     funct3 = (insn >> 12) & 7;
                     switch (funct3) {
                         case 0: /* mul */ val = (intx_t)((intx_t)val * (intx_t)val2); break;
-                        case 1: /* mulh */ goto illegal_insn; val = (intx_t)glue(mulh, XLEN)(val, val2); break;
-                        case 2: /* mulhsu */ goto illegal_insn; val = (intx_t)glue(mulhsu, XLEN)(val, val2); break;
-                        case 3: /* mulhu */ goto illegal_insn; val = (intx_t)glue(mulhu, XLEN)(val, val2); break;
+                        case 1: /* mulh */
+                            if (!s->machine->mulh)
+                                goto illegal_insn;
+                            val = (intx_t)glue(mulh, XLEN)(val, val2); 
+                            break;
+                        case 2: /* mulhsu */
+                            if (!s->machine->mulh)
+                                goto illegal_insn;
+                            val = (intx_t)glue(mulhsu, XLEN)(val, val2); 
+                            break;
+                        case 3: /* mulhu */
+                            if (!s->machine->mulh)
+                                goto illegal_insn;
+                            val = (intx_t)glue(mulhu, XLEN)(val, val2); 
+                            break;
                         case 4: /* div */ val = glue(div, XLEN)(val, val2); break;
                         case 5: /* divu */ val = (intx_t)glue(divu, XLEN)(val, val2); break;
                         case 6: /* rem */ val = glue(rem, XLEN)(val, val2); break;

--- a/include/machine.h
+++ b/include/machine.h
@@ -188,6 +188,9 @@ typedef struct {
     /* Enable atomic instructions */
     bool amo_en;
 
+    /* Enable mulh extention */
+    bool mulh;
+
     /* Enable BlackParrot Host */
     bool host;
 

--- a/include/riscv_machine.h
+++ b/include/riscv_machine.h
@@ -114,6 +114,9 @@ struct RISCVMachine {
     /* Enable atomic instructions */
     bool amo_en;
 
+    /* Enable mulh extention */
+    bool mulh;
+
     /* Enable BlackParrot Host */
     bool host;
 

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -569,6 +569,7 @@ static void usage(const char *prog, const char *msg) {
             "       --clint START:SIZE set CLINT start address and size (defaults to 0x%lx:0x%lx)\n"
             "       --custom_extension add X extension to isa\n"
             "       --enable_amo enables atomic instructions\n"
+            "       --enable_mulh enables mulh extention support\n"
             "       --host enable BlackParrot host\n"
             "       --checkpoint_period creates a checkpoint evey N instructions\n",
             "       --clear_ids clear mvendorid, marchid, mimpid for all cores\n",
@@ -631,6 +632,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     uint64_t    clint_size_override      = 0;
     bool        custom_extension         = false;
     bool        amo_en                   = false;
+    bool        mulh                     = false;
     bool        host                     = false;
     uint64_t    checkpoint_period        = 0;
     const char *simpoint_file            = 0;
@@ -665,6 +667,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             {"clint",                   required_argument, 0,  'C' }, // CFG
             {"custom_extension",              no_argument, 0,  'u' }, // CFG
             {"enable_amo",                    no_argument, 0,  'a' },
+            {"enable_mulh",                   no_argument, 0,  'H' },
             {"host",                          no_argument, 0,  'h' },
             {"checkpoint_period",       required_argument, 0,  'e' },
             {"clear_ids",                     no_argument, 0,  'L' }, // CFG
@@ -825,6 +828,8 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             case 'u': custom_extension = true; break;
 
             case 'a': amo_en = true; break;
+
+            case 'H': mulh = true; break;
 
             case 'h': host = true; break;
 
@@ -1010,6 +1015,9 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
 
     // AMO enable flag
     p->amo_en = amo_en;
+
+    // MULH enable flag
+    p->mulh = mulh;
 
     // BlackParrot Host
     p->host = host;

--- a/src/riscv_machine.cpp
+++ b/src/riscv_machine.cpp
@@ -1188,6 +1188,7 @@ RISCVMachine *virt_machine_init(const VirtMachineParams *p) {
     s->clear_ids = p->clear_ids;
 
     s->amo_en = p->amo_en;
+    s->mulh = p->mulh;
     s->host = p->host;
     s->checkpoint_period = p->checkpoint_period;
 


### PR DESCRIPTION
Added enable_mulh flag to dromajo. This allows dromajo to enable and disable the mulh instruction support at dromajo runtime. 