### PR TITLE
fix param rom offsets for CC_X and CC_Y

### DIFF
--- a/include/riscv_machine.h
+++ b/include/riscv_machine.h
@@ -127,10 +127,11 @@ struct RISCVMachine {
 #define CLINT_BASE_ADDR 0x00300000
 #define CLINT_SIZE      0x000c0000
 
+// These must be kept up to date with the RTL code and SDK aviary.h
 #define PARAM_ROM_BASE_ADDR 0x20000
-#define PARAM_ROM_SIZE 0x0124
-#define PARAM_CC_X_DIM 0x0004
-#define PARAM_CC_Y_DIM 0x0008
+#define PARAM_ROM_SIZE 0x012C
+#define PARAM_CC_X_DIM 0x0000
+#define PARAM_CC_Y_DIM 0x0004
 
 #define HOST_BASE_ADDR 0x00100000
 #define HOST_SIZE      0x00100000


### PR DESCRIPTION
This fixes the emulation mode parameter ROM implementation. This does not impact rtl cosimulation, where param ROM reads are handled by the rtl simulation.